### PR TITLE
Skip CSRF protection check on callback route

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -230,6 +230,12 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Bundler/OrderedGems:
+  Enabled: false
+
+Bundler/DuplicatedGem:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,15 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-if branch < 'v2.0'
-  gem 'rails', '~> 4.2.7'
-  gem 'rails_test_params_backport', group: :test
+if branch == 'master' || branch >= "v2.3"
+  gem 'rails', '~> 5.1.0' # HACK: broken bundler dependency resolution
+  gem "rails-controller-testing", group: :test
+elsif branch >= "v2.0"
+  gem 'rails', '~> 5.0.3' # HACK: broken bundler dependency resolution
+  gem "rails-controller-testing", group: :test
+else
+  gem "rails", '~> 4.2.0' # HACK: broken bundler dependency resolution
+  gem "rails_test_params_backport", group: :test
 end
 
 gemspec

--- a/app/controllers/spree/paybright_controller.rb
+++ b/app/controllers/spree/paybright_controller.rb
@@ -1,5 +1,8 @@
 module Spree
   class PaybrightController < Spree::BaseController
+    # We can't use CSRF protection on a route that's hit by an external service
+    skip_before_action :verify_authenticity_token, only: :callback, raise: false
+
     # Server2server call that gets parameters about the results of the Paybright
     # transaction.
     def callback


### PR DESCRIPTION
This route only gets hit by callbacks from PayBright, which won't have a CSRF token set, and will error if we have CSRF protection enabled in our app.