### PR TITLE
Subtract store credit from total sent to PayBright

### DIFF
--- a/lib/solidus_paybright/params_helper.rb
+++ b/lib/solidus_paybright/params_helper.rb
@@ -15,7 +15,7 @@ module SolidusPaybright
       params = {
         # mandatory parameters
         "x_account_id" => credentials[:api_key],
-        "x_amount" => order.total.to_money.to_s,
+        "x_amount" => order.order_total_after_store_credit.to_money.to_s,
         "x_currency" => order.currency,
         "x_reference" => @payment.id,
         "x_shop_country" => credentials[:shop_country_code],


### PR DESCRIPTION
Since PayBright doesn't allow us to modify payments before capturing them like some other payment methods, we need to ensure we send them the correct amount right away.