### PR TITLE
Update production API URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,7 @@ Performance/Count:
 Style/RaiseArgs:
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Enabled: false
 
 # We can use good judgement here

--- a/app/models/solidus_paybright/configuration.rb
+++ b/app/models/solidus_paybright/configuration.rb
@@ -7,7 +7,7 @@ module SolidusPaybright
 
     attr_writer :live_redirect_url
     def live_redirect_url
-      @live_redirect_url ||= "https://app.healthsmartfinancial.com/checkout/appform.aspx"
+      @live_redirect_url ||= "https://app.paybright.com/checkout/appform.aspx"
     end
 
     attr_writer :test_api_endpoint

--- a/solidus_paybright.gemspec
+++ b/solidus_paybright.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $:.push File.expand_path('../lib', __FILE__)
 require 'solidus_paybright/version'
 
@@ -22,16 +20,16 @@ Gem::Specification.new do |s|
   s.add_dependency 'typhoeus'
 
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'pg'
+  s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '>= 0.38'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
+  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'mysql2'
-  s.add_development_dependency 'pg'
 end

--- a/solidus_paybright.gemspec
+++ b/solidus_paybright.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'mysql2'
-  s.add_development_dependency 'pg'
+  s.add_development_dependency 'pg', '~> 0.21'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '>= 0.38'

--- a/spec/models/spree/payment_method/paybright_spec.rb
+++ b/spec/models/spree/payment_method/paybright_spec.rb
@@ -36,7 +36,7 @@ describe Spree::PaymentMethod::Paybright, type: :model do
         expect(
           payment_method.redirect_url(payment)
         ).to start_with(
-          "https://app.healthsmartfinancial.com/checkout/appform.aspx?x_account_id=api-key&x_amount=110.00&x_currency=USD&"
+          "https://app.paybright.com/checkout/appform.aspx?x_account_id=api-key&x_amount=110.00&x_currency=USD&"
         )
       end
     end


### PR DESCRIPTION
PayBright advised that the current URL will be deprecated some time in the future; this update uses the URL that PayBright has provided as being the most up-to-date.