### PR TITLE
Update staging URL

### DIFF
--- a/app/models/solidus_paybright/configuration.rb
+++ b/app/models/solidus_paybright/configuration.rb
@@ -2,7 +2,7 @@ module SolidusPaybright
   class Configuration < Spree::Preferences::Configuration
     attr_writer :test_redirect_url
     def test_redirect_url
-      @test_redirect_url ||= "https://dev.healthsmartfinancial.com/CheckOut/AppForm.aspx"
+      @test_redirect_url ||= "https://sandbox.paybright.com/CheckOut/AppForm.aspx"
     end
 
     attr_writer :live_redirect_url

--- a/spec/models/spree/payment_method/paybright_spec.rb
+++ b/spec/models/spree/payment_method/paybright_spec.rb
@@ -22,7 +22,7 @@ describe Spree::PaymentMethod::Paybright, type: :model do
         expect(
           payment_method.redirect_url(payment)
         ).to start_with(
-          "https://dev.healthsmartfinancial.com/CheckOut/AppForm.aspx?x_account_id=api-key&x_amount=110.00&x_currency=USD&"
+          "https://sandbox.paybright.com/CheckOut/AppForm.aspx?x_account_id=api-key&x_amount=110.00&x_currency=USD&"
         )
       end
     end


### PR DESCRIPTION
We currently can't test Paybright in staging because we have the old staging URL. This updates to the working staging standbox