### PR TITLE
fix sandbox API endpoint

### DIFF
--- a/app/models/solidus_paybright/configuration.rb
+++ b/app/models/solidus_paybright/configuration.rb
@@ -13,7 +13,7 @@ module SolidusPaybright
     attr_writer :test_api_endpoint
     def test_api_endpoint
       # no trailing slash
-      @test_api_endpoint ||= "https://devapi.paybright.com/api"
+      @test_api_endpoint ||= "https://sandbox.api.paybright.com/api"
     end
 
     attr_writer :live_api_endpoint

--- a/spec/lib/solidus_paybright/api_client_spec.rb
+++ b/spec/lib/solidus_paybright/api_client_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe SolidusPaybright::ApiClient do
-  let(:base_url) { "https://devapi.paybright.com/api" }
+  let(:base_url) { "https://sandbox.api.paybright.com/api" }
 
   subject { described_class.new("api-key", "api-token", base_url) }
 


### PR DESCRIPTION
The domain of the current sandbox API base URL https://devapi.paybright.com/api cannot be resolved. After contacting Paybright, we found out that the correct base URL is https://sandbox.api.paybright.com/api